### PR TITLE
Update query builder, use model connection, key & pagination limit

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -42,9 +42,14 @@ class QueryBuilder
 
     public function __construct(Model $model, Request $request)
     {
-        $this->orderBy = config('api-query-builder.orderBy');
+        $this->orderBy = [
+            [
+            'column' => $model->getKeyName(),
+            'direction' => 'desc'
+            ]
+        ];
 
-        $this->limit = config('api-query-builder.limit');
+        $this->limit = $model->getPerPage();
 
         $this->excludedParameters = array_merge($this->excludedParameters, config('api-query-builder.excludedParameters'));
 
@@ -325,7 +330,7 @@ class QueryBuilder
 
     private function hasTableColumn($column)
     {
-        return (Schema::hasColumn($this->model->getTable(), $column));
+        return (Schema::setConnection($this->model->getConnection())->hasColumn($this->model->getTable(), $column));
     }
 
     private function hasCustomFilter($key)


### PR DESCRIPTION
Update to Query builder, to use model key name and pagination limits. Also amend hasTableColumn method to use the connection specified in the model instead of the default connection when using multiple connections / db's in one project.